### PR TITLE
[#122200041] Fix optional python dependencies of datadog plugins

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -15,14 +15,6 @@ datadog-agent/get-pip.py:
   object_id: 5211ca17-6b2c-4d35-ba72-929b077e2827
   sha: 20da892e83c4f3ae8b523c8a3f8f4e29e935aef7
   size: 1524722
-datadog-agent/requirements-opt.txt:
-  object_id: 3a6257bc-785d-4e28-be52-8172b5b9df7f
-  sha: 8d23e59ce93ef2cbb000440a5a260a4cde1a2a4e
-  size: 1478
-datadog-agent/requirements.txt:
-  object_id: 0feec7b9-3ca9-4360-bafd-7d699be7edd5
-  sha: b76f6d06e38688f1f512952a9ed2b1ebcb7ece3d
-  size: 1926
 apt/python-dev/libexpat1-dev_2.1.0-4ubuntu1.3_amd64.deb:
   object_id: 6ee9956a-7645-46f6-9893-9c1255de9bde
   sha: 70b2766fb83200073459dab66709f14bbb8fef57

--- a/packages/datadog-agent/packaging
+++ b/packages/datadog-agent/packaging
@@ -26,9 +26,7 @@ $VENV_PYTHON_CMD datadog-agent/ez_setup.py --version="$SETUPTOOLS_VERSION" --to-
 $VENV_PYTHON_CMD datadog-agent/get-pip.py
 $VENV_PIP_CMD install "pip==$PIP_VERSION" --global-option=build_ext --global-option="-I$INCLUDE_PATH" --global-option="-L$LD_LIBRARY_PATH"
 $VENV_PIP_CMD install -r datadog-agent/requirements.txt --global-option=build_ext --global-option="-I$INCLUDE_PATH" --global-option="-L$LD_LIBRARY_PATH"
-set +e
 $VENV_PIP_CMD install -r datadog-agent/requirements-opt.txt --global-option=build_ext --global-option="-I$INCLUDE_PATH" --global-option="-L$LD_LIBRARY_PATH"
-set -e
 
 rm -f "$BOSH_INSTALL_TARGET/setuptools-$SETUPTOOLS_VERSION.zip"
 rm -f "$BOSH_INSTALL_TARGET/ez_setup.py"

--- a/src/apt/python-dev/profile.sh
+++ b/src/apt/python-dev/profile.sh
@@ -1,4 +1,4 @@
-export LD_LIBRARY_PATH="/var/vcap/packages/python-dev/apt/usr/lib:${LD_LIBRARY_PATH:-}"
-export INCLUDE_PATH="/var/vcap/packages/python-dev/apt/usr/include:${INCLUDE_PATH:-}"
+export LD_LIBRARY_PATH="/var/vcap/packages/python-dev/apt/usr/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+export INCLUDE_PATH="/var/vcap/packages/python-dev/apt/usr/include:/var/vcap/packages/python-dev/apt/usr/include/python2.7${INCLUDE_PATH:+:${INCLUDE_PATH}}"
 export CPATH="$INCLUDE_PATH"
 export CPPPATH="$INCLUDE_PATH"

--- a/src/datadog-agent/requirements-opt.txt
+++ b/src/datadog-agent/requirements-opt.txt
@@ -1,0 +1,54 @@
+######################## WARNING ##########################
+# This file currently determines the python deps installed
+# for the dev env, the source install and the Win build.
+# It is NOT used for the DEB/RPM packages and the OS X
+# build. For these please update:
+# https://github.com/DataDog/omnibus-software
+###########################################################
+
+# core/optional
+# tornado can work without pycurl and use the simple http client
+# but some features won't work, like the abylity to use a proxy
+# Require a compiler and the curl headers+lib
+# On windows - manual install of pycurl might be easier.
+pycurl==7.19.5.1
+
+# core-ish/system -> system check on windows
+# checks.d/process.py
+# checks.d/gunicorn.py
+# checks.d/btrfs.py
+# checks.d/system_core.py
+psutil==3.3.0
+
+# checks.d/snmp.py
+# Require a compiler because pycrypto is a dep
+pysnmp-mibs==0.1.4
+pysnmp==4.2.5
+
+# checks.d/mongo.py
+# checks.d/tokumx.py
+# Require a compiler
+# TODO: our checks are not compatible with 3.x
+pymongo==3.2
+
+# checks.d/kafka_consumer.py
+# Requires a compiler because zope.interface is a dep
+kazoo==1.3.1
+
+# checks.d/ssh_check.py
+winrandom-ctypes
+# Require a compiler because pycrypto is a dep
+paramiko==1.15.2
+
+# checks.d/pgbouncer.py
+# Require libpq
+psycopg2==2.6
+
+# checks.d/win32_event_log.py
+# checks.d/wmi.py
+# It's a pure python module, it doesn't require anything to install,
+# but needs the pywin32 extension to work
+wmi==1.4.9
+
+# checks.d/directory.py
+scandir==1.2

--- a/src/datadog-agent/requirements-opt.txt
+++ b/src/datadog-agent/requirements-opt.txt
@@ -36,19 +36,8 @@ pymongo==3.2
 kazoo==1.3.1
 
 # checks.d/ssh_check.py
-winrandom-ctypes
 # Require a compiler because pycrypto is a dep
 paramiko==1.15.2
-
-# checks.d/pgbouncer.py
-# Require libpq
-psycopg2==2.6
-
-# checks.d/win32_event_log.py
-# checks.d/wmi.py
-# It's a pure python module, it doesn't require anything to install,
-# but needs the pywin32 extension to work
-wmi==1.4.9
 
 # checks.d/directory.py
 scandir==1.2

--- a/src/datadog-agent/requirements.txt
+++ b/src/datadog-agent/requirements.txt
@@ -1,0 +1,78 @@
+######################## WARNING ##########################
+# This file currently determines the python deps installed
+# for the dev env, the source install and the Win build.
+# It is NOT used for the DEB/RPM packages and the OS X
+# build. For these please update:
+# https://github.com/DataDog/omnibus-software
+###########################################################
+
+###########################################################
+# These modules are the deps needed by the
+# agent core, meaning every module that is
+# not a check
+# They're installed in the CI and when doing
+# a source install
+# If their installation fails the agent installation
+# fails, so they shouldn't have too many deps
+###########################################################
+
+boto==2.39.0
+ntplib==0.3.3
+# the libyaml bindings are optional
+pyyaml==3.11
+# note: requests is also used in many checks
+# upgrade with caution
+requests==2.6.0
+# note: simplejson is used in many checks to inteface APIs
+simplejson==3.6.5
+supervisor==3.3.0
+tornado==3.2.2
+uptime==3.0.1
+
+###########################################################
+# These modules are for checks. But they are
+# installable just fine anywhere. So we install
+# them all. They're usually pure python and don't
+# need any external deps.
+###########################################################
+
+# checks.d/sqlserver.py
+adodbapi==2.6.0.7
+pyro4==4.35 # required by adodbapi
+
+# checks.d/riak.py
+httplib2==0.9
+
+# checks.d/kafka_consumer.py
+kafka-python==0.9.3
+
+# checks.d/postgres.py
+pg8000==1.10.1
+
+# checks.d/mysql.py
+pymysql==0.6.6
+
+# checks.d/gearman.py
+gearman==2.0.2
+
+# checks.d/mcache.py
+python-memcached==1.53
+
+# checks.d/redis.py
+redis==2.10.3
+
+# checks.d/vsphere.py
+pyvmomi==6.0.0
+
+# checks.d/hdfs.py
+snakebite==1.3.11
+
+# utils/platform.py
+docker-py==1.8.1
+
+# checks.d/dns_check.py
+dnspython==1.12.0
+
+# utils/service_discovery/config_stores.py
+python-etcd==0.4.2
+python-consul==0.4.7


### PR DESCRIPTION
[#122200041 Check health of go router](https://www.pivotaltracker.com/story/show/122200041)
# What?

We want to start using the [`process.py` process check](http://docs.datadoghq.com/integrations/process/) from datadog to monitor gorouter and other processes.

But the agent fails because python library `psutils` is not installed. We found out that our release does not install the optional dependencies due some misconfiguration.

In this PR we fix this issue and install all the requirements we can for optional plugins.
## How to review?

For this case, we want to propose an alternate approach: [use `bosh-lite`](https://github.com/cloudfoundry/bosh-lite).

You can follow the instructions on the repo or this quick guide:
1. Check that you have `vagrant` and `Virtualbox` installed. I can be run on AWS, but we did not test it. Check the `bosh-lite` docs for that.
   Install bosh_cli with `gem install bosh_cli`.
2. Start bosh-lite:
   
   ```
   git clone https://github.com/cloudfoundry/bosh-lite
   vagrant up
   
   bosh target 192.168.50.4 lite # Login: admin Pass: admin
   ```
3. Build this release and upload it:
   
   ```
   bosh create release --with-tarball
   
   bosh upload release /home/keymon/gds/paas-datadog-agent-boshrelease/dev_releases/datadog-agent/datadog-agent-5.8.5.1+dev.1.tgz # update the version accordingly
   ```
4. Create the manifest below:
   
   ```
   cat > /tmp/manifest.yml <<EOF
   ---
   name: datadog-test
   director_uuid: DIRECTOR_UUID
   
   releases:
   - name: datadog-agent
   version: latest
   
   networks:
   - name: default
   subnets:
   - range: 10.244.0.0/28
     reserved: [10.244.0.1]
     static: [10.244.0.2,10.244.0.6,10.244.0.10]
     cloud_properties:
       name: random
   
   resource_pools:
   - name: default
   stemcell:
     name: bosh-warden-boshlite-ubuntu-trusty-go_agent
     version: "3262.2"
   network: default
   cloud_properties: {}
   
   compilation:
   workers: 2
   network: default
   cloud_properties: {}
   
   update:
   canaries: 1
   canary_watch_time: 60000
   update_watch_time: 60000
   max_in_flight: 2
   
   jobs:
   - name: app
   templates:
   - name: datadog-agent
   instances: 1
   resource_pool: default
   networks:
   - name: default
     static_ips:
     - 10.244.0.2
   properties:
   api_key: mykey
   hostname: hehe
   
   EOF
   ```
   1. Change the bosh uuid: `gsed -i "s/DIRECTOR_UUID/$(bosh status --uuid)/" /tmp/manifest.yml`
   2. Target the deployment and deploy:
      `
      bosh deployment /tmp/manifest.yml
      bosh deploy
      `

It should succeed deploying. Now you can ssh to the "vm":

```
vagrant ssh # ssh into bosh-lite
bosh ssh app
```

Enable the "process check" in the datadog agent:

```
cp /var/vcap/packages/datadog-agent/agent/conf.d/process.yaml.example /var/vcap/packages/datadog-agent/agent/conf.d/process.yaml
monit restart datadog-agent-collector
```

The logs should report that it started OK, without python errors:

```
less /var/vcap/sys/log/datadog-agent/collector.log
```
## Post-merge
- We should build a release and uploaded as a "Github release".
- Submit this upstream.
## Who?

Anyone but @richardc or me
