### PR TITLE
[#122200041]  Merge upstream/master into gds_master

### DIFF
--- a/.final_builds/jobs/datadog-agent/index.yml
+++ b/.final_builds/jobs/datadog-agent/index.yml
@@ -4,4 +4,8 @@ builds:
     version: f2847a71cc50926bc5cd706a0fcbc7277f8354e5
     sha1: c64117d96dc4c5053684efe65889fa16fcc6380a
     blobstore_id: 52cf274a-ab6f-42b0-ab17-1662ff55e9a3
+  2d3944b162852a506e46b85d799e6dbeac443dce:
+    version: 2d3944b162852a506e46b85d799e6dbeac443dce
+    sha1: 33357726756b8e7a844cf0585241b36aa1609c79
+    blobstore_id: f67f7f1c-2cc6-48c4-8fae-e0dd32fb4915
 format-version: '2'

--- a/.final_builds/packages/datadog-agent/index.yml
+++ b/.final_builds/packages/datadog-agent/index.yml
@@ -8,4 +8,8 @@ builds:
     version: f2e1700c2eb33249652b9282e0b40fe6226d83dc
     sha1: 06f4ff984179e020a2ba6e08e86c71d6812f95f2
     blobstore_id: 4e586a36-fc40-4a7f-a701-9dffe1954ac9
+  f466dd5ff097ebf5ca729e3a8e1a79e5abad989b:
+    version: f466dd5ff097ebf5ca729e3a8e1a79e5abad989b
+    sha1: 068a9f520ddad12c34eae4963be0c0fa9f6c8092
+    blobstore_id: 4f09e831-08aa-4e50-904f-cc30b90a1da0
 format-version: '2'

--- a/.final_builds/packages/python-dev/index.yml
+++ b/.final_builds/packages/python-dev/index.yml
@@ -4,4 +4,8 @@ builds:
     version: 102a0247486b438a61fbe94b7bbb22b5e96834ab
     sha1: b9cd3959aa013c4a68c91989dc228e25f49151ef
     blobstore_id: 595d82ca-a615-4d76-b628-621ebc8ca6e5
+  e3b2dd781300c56102aa046428069c2648ddd4a5:
+    version: e3b2dd781300c56102aa046428069c2648ddd4a5
+    sha1: 190536c377c3bbd0a0e44e1b58857d7542a6c58e
+    blobstore_id: 51db8f7a-8c37-4e1a-b33a-51a42f5993ac
 format-version: '2'

--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ instance_groups:
         service: myservice
 ```
 
+### Agent integrations
+
+Some Datadog integrations are configured in the agent: https://github.com/DataDog/dd-agent/tree/5.8.5/conf.d
+They might depend on "optional" dependencies in the agent: https://github.com/DataDog/dd-agent/blob/5.8.5/requirements-opt.txt
+The `datadog-agent` package installs these but some fail due to missing dependencies.
+These packages are skipped:
+
+* `pgbouncer` depends on `libpq`, which this release does not include
+* `ssh_check` depends on `winrandom-ctypes`, which will only install on Windows
+* `win32_event_log` and `wmi` will only work on Windows
+
 ## Development
 
 As a developer of this release, create new releases and upload them:

--- a/README.md
+++ b/README.md
@@ -66,6 +66,26 @@ These packages are skipped:
 * `ssh_check` depends on `winrandom-ctypes`, which will only install on Windows
 * `win32_event_log` and `wmi` will only work on Windows
 
+Configure integrations by embedding the YAML in the properties:
+
+```
+instance_groups:
+- name: myservice
+  jobs:
+  - name: datadog-agent
+    release: datadog-agent
+    properties:
+      integrations:
+        process:
+          init_config:
+            pid_cache_duration: 30
+          instances:
+          - name: myservice
+            search_string: ["myservice"]
+            thresholds:
+              critical: [1, 9]
+```
+
 ## Development
 
 As a developer of this release, create new releases and upload them:

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -16,9 +16,9 @@ datadog-agent/get-pip.py:
   sha: 20da892e83c4f3ae8b523c8a3f8f4e29e935aef7
   size: 1524722
 datadog-agent/requirements-opt.txt:
-  object_id: 3a6257bc-785d-4e28-be52-8172b5b9df7f
-  sha: 8d23e59ce93ef2cbb000440a5a260a4cde1a2a4e
-  size: 1478
+  object_id: 957fa648-9eb3-4673-b2da-391a64042c8d
+  sha: 069e5471ce75437a4427a79109cfd7cd4976a138
+  size: 1484
 datadog-agent/requirements.txt:
   object_id: 0feec7b9-3ca9-4360-bafd-7d699be7edd5
   sha: b76f6d06e38688f1f512952a9ed2b1ebcb7ece3d

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -15,14 +15,6 @@ datadog-agent/get-pip.py:
   object_id: 5211ca17-6b2c-4d35-ba72-929b077e2827
   sha: 20da892e83c4f3ae8b523c8a3f8f4e29e935aef7
   size: 1524722
-datadog-agent/requirements-opt.txt:
-  object_id: 957fa648-9eb3-4673-b2da-391a64042c8d
-  sha: 069e5471ce75437a4427a79109cfd7cd4976a138
-  size: 1484
-datadog-agent/requirements.txt:
-  object_id: 0feec7b9-3ca9-4360-bafd-7d699be7edd5
-  sha: b76f6d06e38688f1f512952a9ed2b1ebcb7ece3d
-  size: 1926
 apt/python-dev/libexpat1-dev_2.1.0-4ubuntu1.3_amd64.deb:
   object_id: 6ee9956a-7645-46f6-9893-9c1255de9bde
   sha: 70b2766fb83200073459dab66709f14bbb8fef57

--- a/jobs/datadog-agent/monit
+++ b/jobs/datadog-agent/monit
@@ -10,8 +10,10 @@ check process datadog-agent-forwarder
   stop program "/var/vcap/jobs/datadog-agent/bin/monit_debugger forwarder_ctl '/var/vcap/jobs/datadog-agent/bin/forwarder_ctl stop'"
   group vcap
 
+<% if p('use_dogstatsd') == 'yes' %>
 check process datadog-agent-dogstatsd
   with pidfile /var/vcap/sys/run/datadog-agent/dogstatsd.pid
   start program "/var/vcap/jobs/datadog-agent/bin/monit_debugger dogstatsd_ctl '/var/vcap/jobs/datadog-agent/bin/dogstatsd_ctl start'"
   stop program "/var/vcap/jobs/datadog-agent/bin/monit_debugger dogstatsd_ctl '/var/vcap/jobs/datadog-agent/bin/dogstatsd_ctl stop'"
   group vcap
+<% end %>

--- a/jobs/datadog-agent/spec
+++ b/jobs/datadog-agent/spec
@@ -22,3 +22,8 @@ properties:
   tags:
     default: {}
     description: A dictionary of tag names and values for categories that will be applied to the data sent from this agent.
+  integrations:
+    default: {}
+    description: |
+      Agent integration configuration.
+      Each key will have ".yaml" appended to it and the value dumped into that file in `AGENT_DIR/conf.d/`.

--- a/jobs/datadog-agent/spec
+++ b/jobs/datadog-agent/spec
@@ -19,6 +19,9 @@ properties:
     description: Collect AWS EC2 custom tags as agent tags (requires an IAM role associated with the instance)
   hostname:
     description: Hostname as it should be displayed within datadog. Optional.
+  use_dogstatsd:
+    default: yes
+    description: Should the dogstatsd agent be started
   tags:
     default: {}
     description: A dictionary of tag names and values for categories that will be applied to the data sent from this agent.

--- a/jobs/datadog-agent/templates/bin/collector_ctl
+++ b/jobs/datadog-agent/templates/bin/collector_ctl
@@ -9,6 +9,7 @@ export PORT=${PORT:-5000}
 export LANG=en_US.UTF-8
 # hard-coded in agent.py to use this path
 PIDFILE=$TMP_DIR/dd-agent.pid
+INTEGRATION_DIR="$AGENT_DIR/conf.d"
 
 case $1 in
 
@@ -16,6 +17,14 @@ case $1 in
     pid_guard $PIDFILE $JOB_NAME
 
     cp $JOB_DIR/config/datadog.conf "$AGENT_DIR/"
+
+    rm -f "$INTEGRATION_DIR/*"
+    <% p("integrations").each do |integration, config| %>
+    mkdir -p "$INTEGRATION_DIR"
+    cat <<YAML > "$INTEGRATION_DIR/<%= integration %>.yaml"
+<%= JSON.dump(config) %>
+YAML
+    <% end %>
 
     export PYTHONPATH="$AGENT_DIR/checks/libs:$PYTHONPATH"
     export LANG=POSIX

--- a/jobs/datadog-agent/templates/config/datadog.conf.erb
+++ b/jobs/datadog-agent/templates/config/datadog.conf.erb
@@ -123,7 +123,7 @@ use_mount: no
 # ========================================================================== #
 
 # If you don't want to enable the DogStatsd server, set this option to no
-# use_dogstatsd: yes
+use_dogstatsd: <%= p("use_dogstatsd") %>
 
 # DogStatsd is a small server that aggregates your custom app metrics. For
 # usage information, check out http://docs.datadoghq.com/guides/dogstatsd/

--- a/jobs/datadog-agent/templates/helpers/ctl_setup.sh
+++ b/jobs/datadog-agent/templates/helpers/ctl_setup.sh
@@ -18,11 +18,6 @@ output_label=${2:-${JOB_NAME}}
 export JOB_DIR=/var/vcap/jobs/$JOB_NAME
 chmod 755 $JOB_DIR # to access file via symlink
 
-# Load some bosh deployment properties into env vars
-# Try to put all ERb into data/properties.sh.erb
-# incl $NAME, $JOB_INDEX, $WEBAPP_DIR
-source $JOB_DIR/data/properties.sh
-
 source $JOB_DIR/helpers/ctl_utils.sh
 redirect_output ${output_label}
 
@@ -50,6 +45,11 @@ do
     export LD_LIBRARY_PATH=${package_dir}/lib:$LD_LIBRARY_PATH
   fi
 done
+
+# Load some bosh deployment properties into env vars
+# Try to put all ERb into data/properties.sh.erb
+# incl $NAME, $JOB_INDEX, $WEBAPP_DIR
+source $JOB_DIR/data/properties.sh
 
 # Setup log, run and tmp folders
 

--- a/packages/datadog-agent/packaging
+++ b/packages/datadog-agent/packaging
@@ -26,9 +26,7 @@ $VENV_PYTHON_CMD datadog-agent/ez_setup.py --version="$SETUPTOOLS_VERSION" --to-
 $VENV_PYTHON_CMD datadog-agent/get-pip.py
 $VENV_PIP_CMD install "pip==$PIP_VERSION" --global-option=build_ext --global-option="-I$INCLUDE_PATH" --global-option="-L$LD_LIBRARY_PATH"
 $VENV_PIP_CMD install -r datadog-agent/requirements.txt --global-option=build_ext --global-option="-I$INCLUDE_PATH" --global-option="-L$LD_LIBRARY_PATH"
-set +e
 $VENV_PIP_CMD install -r datadog-agent/requirements-opt.txt --global-option=build_ext --global-option="-I$INCLUDE_PATH" --global-option="-L$LD_LIBRARY_PATH"
-set -e
 
 rm -f "$BOSH_INSTALL_TARGET/setuptools-$SETUPTOOLS_VERSION.zip"
 rm -f "$BOSH_INSTALL_TARGET/ez_setup.py"

--- a/releases/datadog-agent/datadog-agent-5.8.5.2.yml
+++ b/releases/datadog-agent/datadog-agent-5.8.5.2.yml
@@ -1,0 +1,26 @@
+---
+packages:
+- name: datadog-agent
+  version: f466dd5ff097ebf5ca729e3a8e1a79e5abad989b
+  fingerprint: f466dd5ff097ebf5ca729e3a8e1a79e5abad989b
+  sha1: 068a9f520ddad12c34eae4963be0c0fa9f6c8092
+  dependencies:
+  - python-dev
+- name: python-dev
+  version: e3b2dd781300c56102aa046428069c2648ddd4a5
+  fingerprint: e3b2dd781300c56102aa046428069c2648ddd4a5
+  sha1: 190536c377c3bbd0a0e44e1b58857d7542a6c58e
+  dependencies: []
+jobs:
+- name: datadog-agent
+  version: 2d3944b162852a506e46b85d799e6dbeac443dce
+  fingerprint: 2d3944b162852a506e46b85d799e6dbeac443dce
+  sha1: 33357726756b8e7a844cf0585241b36aa1609c79
+license:
+  version: 94ec8797c1898217dbe180bb79797f5650233335
+  fingerprint: 94ec8797c1898217dbe180bb79797f5650233335
+  sha1: fd89eb46cac1d9ed12ef859e7be2c9de11b0f6c2
+commit_hash: f6552e7d
+uncommitted_changes: true
+name: datadog-agent
+version: 5.8.5.2

--- a/releases/datadog-agent/index.yml
+++ b/releases/datadog-agent/index.yml
@@ -4,4 +4,6 @@ builds:
     version: 5.8.5.0
   810bb0e2-e715-400c-b29d-e733e17c5c61:
     version: 5.8.5.1
+  ff4de73d-e8b4-485d-9e24-add47a2b2b2f:
+    version: 5.8.5.2
 format-version: '2'

--- a/src/apt/python-dev/profile.sh
+++ b/src/apt/python-dev/profile.sh
@@ -1,4 +1,16 @@
-export LD_LIBRARY_PATH="/var/vcap/packages/python-dev/apt/usr/lib:${LD_LIBRARY_PATH:-}"
-export INCLUDE_PATH="/var/vcap/packages/python-dev/apt/usr/include:${INCLUDE_PATH:-}"
+ld_library_path="/var/vcap/packages/python-dev/apt/usr/lib"
+if [ -n "${LD_LIBRARY_PATH:-}" ]; then
+  export LD_LIBRARY_PATH="$ld_library_path:$LD_LIBRARY_PATH"
+else
+  export LD_LIBRARY_PATH="$ld_library_path"
+fi
+
+include_path="/var/vcap/packages/python-dev/apt/usr/include:/var/vcap/packages/python-dev/apt/usr/include/python2.7"
+if [ -n "${INCLUDE_PATH:-}" ]; then
+  export INCLUDE_PATH="$include_path:$INCLUDE_PATH"
+else
+  export INCLUDE_PATH="$include_path"
+fi
+
 export CPATH="$INCLUDE_PATH"
 export CPPPATH="$INCLUDE_PATH"

--- a/src/datadog-agent/requirements-opt.txt
+++ b/src/datadog-agent/requirements-opt.txt
@@ -1,0 +1,54 @@
+######################## WARNING ##########################
+# This file currently determines the python deps installed
+# for the dev env, the source install and the Win build.
+# It is NOT used for the DEB/RPM packages and the OS X
+# build. For these please update:
+# https://github.com/DataDog/omnibus-software
+###########################################################
+
+# core/optional
+# tornado can work without pycurl and use the simple http client
+# but some features won't work, like the abylity to use a proxy
+# Require a compiler and the curl headers+lib
+# On windows - manual install of pycurl might be easier.
+pycurl==7.19.5.1
+
+# core-ish/system -> system check on windows
+# checks.d/process.py
+# checks.d/gunicorn.py
+# checks.d/btrfs.py
+# checks.d/system_core.py
+psutil==3.3.0
+
+# checks.d/snmp.py
+# Require a compiler because pycrypto is a dep
+pysnmp-mibs==0.1.4
+pysnmp==4.2.5
+
+# checks.d/mongo.py
+# checks.d/tokumx.py
+# Require a compiler
+# TODO: our checks are not compatible with 3.x
+pymongo==3.2
+
+# checks.d/kafka_consumer.py
+# Requires a compiler because zope.interface is a dep
+kazoo==1.3.1
+
+# checks.d/ssh_check.py
+# winrandom-ctypes
+# Require a compiler because pycrypto is a dep
+paramiko==1.15.2
+
+# checks.d/pgbouncer.py
+# Require libpq
+# psycopg2==2.6
+
+# checks.d/win32_event_log.py
+# checks.d/wmi.py
+# It's a pure python module, it doesn't require anything to install,
+# but needs the pywin32 extension to work
+# wmi==1.4.9
+
+# checks.d/directory.py
+scandir==1.2

--- a/src/datadog-agent/requirements.txt
+++ b/src/datadog-agent/requirements.txt
@@ -1,0 +1,78 @@
+######################## WARNING ##########################
+# This file currently determines the python deps installed
+# for the dev env, the source install and the Win build.
+# It is NOT used for the DEB/RPM packages and the OS X
+# build. For these please update:
+# https://github.com/DataDog/omnibus-software
+###########################################################
+
+###########################################################
+# These modules are the deps needed by the
+# agent core, meaning every module that is
+# not a check
+# They're installed in the CI and when doing
+# a source install
+# If their installation fails the agent installation
+# fails, so they shouldn't have too many deps
+###########################################################
+
+boto==2.39.0
+ntplib==0.3.3
+# the libyaml bindings are optional
+pyyaml==3.11
+# note: requests is also used in many checks
+# upgrade with caution
+requests==2.6.0
+# note: simplejson is used in many checks to inteface APIs
+simplejson==3.6.5
+supervisor==3.3.0
+tornado==3.2.2
+uptime==3.0.1
+
+###########################################################
+# These modules are for checks. But they are
+# installable just fine anywhere. So we install
+# them all. They're usually pure python and don't
+# need any external deps.
+###########################################################
+
+# checks.d/sqlserver.py
+adodbapi==2.6.0.7
+pyro4==4.35 # required by adodbapi
+
+# checks.d/riak.py
+httplib2==0.9
+
+# checks.d/kafka_consumer.py
+kafka-python==0.9.3
+
+# checks.d/postgres.py
+pg8000==1.10.1
+
+# checks.d/mysql.py
+pymysql==0.6.6
+
+# checks.d/gearman.py
+gearman==2.0.2
+
+# checks.d/mcache.py
+python-memcached==1.53
+
+# checks.d/redis.py
+redis==2.10.3
+
+# checks.d/vsphere.py
+pyvmomi==6.0.0
+
+# checks.d/hdfs.py
+snakebite==1.3.11
+
+# utils/platform.py
+docker-py==1.8.1
+
+# checks.d/dns_check.py
+dnspython==1.12.0
+
+# utils/service_discovery/config_stores.py
+python-etcd==0.4.2
+python-consul==0.4.7


### PR DESCRIPTION
Upstream has features that we want to build on, so merge upstream
## How to test?

The most interesting change is be able to run the process check.  

For this case, we want to propose an alternate approach: [use `bosh-lite`](https://github.com/cloudfoundry/bosh-lite).

You can follow the instructions on the repo or this quick guide:
1. Check that you have `vagrant` and `Virtualbox` installed. I can be run on AWS, but we did not test it. Check the `bosh-lite` docs for that.
   Install bosh_cli with `gem install bosh_cli`.
2. Start bosh-lite:
   
   ```
   git clone https://github.com/cloudfoundry/bosh-lite
   vagrant up
   
   bosh target 192.168.50.4 lite # Login: admin Pass: admin
   ```
3. Build this release and upload it:
   
   ```
   bosh create release --with-tarball
   
   bosh upload release /home/keymon/gds/paas-datadog-agent-boshrelease/dev_releases/datadog-agent/datadog-agent-5.8.5.1+dev.1.tgz # update the version accordingly
   
   bosh upload stemcell https://bosh.io/d/stemcells/bosh-warden-boshlite-ubuntu-trusty-go_agent?v=3262.2
   ```
4. Create the manifest below:
   
   ```
   cat > /tmp/manifest.yml <<EOF
   ---
   name: datadog-test
   director_uuid: DIRECTOR_UUID
   
   releases:
   - name: datadog-agent
   version: latest
   
   networks:
   - name: default
   subnets:
   - range: 10.244.0.0/28
     reserved: [10.244.0.1]
     static: [10.244.0.2,10.244.0.6,10.244.0.10]
     cloud_properties:
       name: random
   
   resource_pools:
   - name: default
   stemcell:
     name: bosh-warden-boshlite-ubuntu-trusty-go_agent
     version: "3262.2"
   network: default
   cloud_properties: {}
   
   compilation:
   workers: 2
   network: default
   cloud_properties: {}
   
   update:
   canaries: 1
   canary_watch_time: 60000
   update_watch_time: 60000
   max_in_flight: 2
   
   jobs:
   - name: app
   templates:
   - name: datadog-agent
   instances: 1
   resource_pool: default
   networks:
   - name: default
     static_ips:
     - 10.244.0.2
   properties:
   api_key: mykey
   hostname: hehe
   
   EOF
   ```
   1. Change the bosh uuid: `gsed -i "s/DIRECTOR_UUID/$(bosh status --uuid)/" /tmp/manifest.yml`
   2. Target the deployment and deploy:
      `
      bosh deployment /tmp/manifest.yml
      bosh deploy
      `

It should succeed deploying. Now you can ssh to the "vm":

```
vagrant ssh # ssh into bosh-lite
bosh ssh app
```

Enable the "process check" in the datadog agent:

```
cp /var/vcap/packages/datadog-agent/agent/conf.d/process.yaml.example /var/vcap/packages/datadog-agent/agent/conf.d/process.yaml
monit restart datadog-agent-collector
```

The logs should report that it started OK, without python errors:

```
less /var/vcap/sys/log/datadog-agent/collector.log
```
## Who can review

Not @richardc
