### PR TITLE
[#122200041] Merge integrations conf from 3rd party jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,16 +57,17 @@ instance_groups:
 
 ### Agent integrations
 
-Some Datadog integrations are configured in the agent: https://github.com/DataDog/dd-agent/tree/5.8.5/conf.d
-They might depend on "optional" dependencies in the agent: https://github.com/DataDog/dd-agent/blob/5.8.5/requirements-opt.txt
-The `datadog-agent` package installs these but some fail due to missing dependencies.
-These packages are skipped:
+Some [Datadog integrations are configured in the agent](https://github.com/DataDog/dd-agent/tree/5.8.5/conf.d).
+This release has support to configure them.
 
-* `pgbouncer` depends on `libpq`, which this release does not include
-* `ssh_check` depends on `winrandom-ctypes`, which will only install on Windows
-* `win32_event_log` and `wmi` will only work on Windows
+Note: These integrations depend on ["optional" dependencies in the agent](https://github.com/DataDog/dd-agent/blob/5.8.5/requirements-opt.txt).
+The `datadog-agent` package installs these but some fail due to missing dependencies. Currently these packages are not working:
 
-Configure integrations by embedding the YAML in the properties:
+  * `pgbouncer` depends on `libpq`, which this release does not include
+
+#### Configuring integrations adhoc in the manifest
+
+The end user can configure integrations by embedding the YAML in the properties:
 
 ```
 instance_groups:
@@ -85,6 +86,20 @@ instance_groups:
             thresholds:
               critical: [1, 9]
 ```
+
+#### Configuring integrations from 3rd party releases
+
+Third party releases might want to extend datadog agent to monitor local services using these additional checks.
+
+This release has logic to merge all files from jobs which follow this pattern:
+
+  ${JOB_PATH}/config/datadog-integrations/${checkname}.yaml
+
+For example:
+
+  /var/vcap/jobs/datadog-router/config/datadog-integrations/process.yaml
+
+The script will use [spruce](https://github.com/geofffranks/spruce) to merge all the configurations in one unique file per check, as datadog agent expects. Merging the config with spruces allows multiple jobs add configuration for some checks, for instance to monitor different processes. Additionally the release developer can use [the spruce syntax](https://github.com/geofffranks/spruce) if the need to, although default merge strategy is good enough.
 
 ## Development
 

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -59,3 +59,7 @@ apt/python-dev/python2.7_2.7.6-8ubuntu0.2_amd64.deb:
   object_id: 48a21a13-f31d-4794-9033-69cdb47dfe05
   sha: b87ff6940cd17466e867a5e1e6f70fbca14cfe0c
   size: 195822
+spruce/spruce:
+  object_id: a4b53617-9fb1-4085-b6dd-82b7783b7c9c
+  sha: 233fa7fc416e1213c63711eb7c3f0b94f000d131
+  size: 10594008

--- a/jobs/datadog-agent/spec
+++ b/jobs/datadog-agent/spec
@@ -2,6 +2,7 @@
 name: datadog-agent
 packages:
 - datadog-agent
+- spruce
 templates:
   bin/collector_ctl: bin/collector_ctl
   bin/dogstatsd_ctl: bin/dogstatsd_ctl
@@ -11,6 +12,8 @@ templates:
   data/properties.sh.erb: data/properties.sh
   helpers/ctl_setup.sh: helpers/ctl_setup.sh
   helpers/ctl_utils.sh: helpers/ctl_utils.sh
+  helpers/merge_integrations_conf.sh: helpers/merge_integrations_conf.sh
+  helpers/generate_integrations_conf.sh: helpers/generate_integrations_conf.sh
 
 properties:
   api_key:

--- a/jobs/datadog-agent/templates/bin/collector_ctl
+++ b/jobs/datadog-agent/templates/bin/collector_ctl
@@ -9,7 +9,6 @@ export PORT=${PORT:-5000}
 export LANG=en_US.UTF-8
 # hard-coded in agent.py to use this path
 PIDFILE=$TMP_DIR/dd-agent.pid
-INTEGRATION_DIR="$AGENT_DIR/conf.d"
 
 case $1 in
 
@@ -17,14 +16,8 @@ case $1 in
     pid_guard $PIDFILE $JOB_NAME
 
     cp $JOB_DIR/config/datadog.conf "$AGENT_DIR/"
-
-    rm -f "$INTEGRATION_DIR/*"
-    <% p("integrations").each do |integration, config| %>
-    mkdir -p "$INTEGRATION_DIR"
-    cat <<YAML > "$INTEGRATION_DIR/<%= integration %>.yaml"
-<%= JSON.dump(config) %>
-YAML
-    <% end %>
+    bash $JOB_DIR/helpers/generate_integrations_conf.sh
+    bash $JOB_DIR/helpers/merge_integrations_conf.sh
 
     export PYTHONPATH="$AGENT_DIR/checks/libs:$PYTHONPATH"
     export LANG=POSIX

--- a/jobs/datadog-agent/templates/helpers/generate_integrations_conf.sh
+++ b/jobs/datadog-agent/templates/helpers/generate_integrations_conf.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+set -u
+
+INTEGRATION_DIR="/var/vcap/jobs/datadog-agent/config/datadog-integrations"
+
+mkdir -p "${INTEGRATION_DIR}"
+rm -f "${INTEGRATION_DIR}/*"
+
+<% p("integrations").each do |integration, config| %>
+mkdir -p "$INTEGRATION_DIR"
+cat <<YAML > "$INTEGRATION_DIR/<%= integration %>.yaml"
+<%= JSON.dump(config) %>
+YAML
+<% end %>

--- a/jobs/datadog-agent/templates/helpers/merge_integrations_conf.sh
+++ b/jobs/datadog-agent/templates/helpers/merge_integrations_conf.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+set -u
+
+SPRUCE=/var/vcap/packages/spruce/bin/spruce
+JOBS_PATH=/var/vcap/jobs
+DD_AGENT_HOME=/var/vcap/packages/datadog-agent/agent
+
+rm -f "${DD_AGENT_HOME}"/conf.d/*.yaml
+
+check_file_names=$(find -L "${JOBS_PATH}" -maxdepth 4 -mindepth 4 -type f -a -path '*/config/datadog-integrations/*yaml' -printf '%f\n' | sort -u)
+
+for f in ${check_file_names}; do
+  files_to_merge=$(find -L "${JOBS_PATH}" -maxdepth 4 -mindepth 4 -type f -a -path "*/config/datadog-integrations/${f}")
+  "${SPRUCE}" merge ${files_to_merge} > "${DD_AGENT_HOME}"/conf.d/"${f}"
+done

--- a/packages/spruce/packaging
+++ b/packages/spruce/packaging
@@ -1,0 +1,11 @@
+set -e # exit immediately if a simple command exits with a non-zero status
+set -u # report the usage of uninitialized variables
+
+ # Available variables
+# $BOSH_COMPILE_TARGET - where this package & spec'd source files are available
+# $BOSH_INSTALL_TARGET - where you copy/install files to be included in package
+
+BIN=spruce
+mkdir ${BOSH_INSTALL_TARGET}/bin
+cp ${BIN}/${BIN} ${BOSH_INSTALL_TARGET}/bin
+chmod 755 ${BOSH_INSTALL_TARGET}/bin/${BIN}

--- a/packages/spruce/spec
+++ b/packages/spruce/spec
@@ -1,0 +1,5 @@
+---
+name: spruce
+dependencies: []
+files:
+- spruce/spruce


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/122200041
# NOTE: dependencies and next steps.

This is a copy of the upstream PR https://github.com/onemedical/datadog-agent-boshrelease/pull/7, so we can use it meanwhile it is not merged upstream. 

This PR includes a commit to change the bucket for blobs, as it adds a new blob for spruce. The bucket is configured in https://github.com/alphagov/paas-bootstrap/pull/2

In order the copy the binaries across, we run a script like:

```
git grep -h blobstore_id   | awk '{print $2}' | \
    xargs -I {} aws s3 cp \
    s3://omg-boshrelease-blobs/{} \
    s3://gds-paas-datadog-agent-boshrelease/{}

 git grep -h object_id   | awk '{print $2}' | \
     xargs -I {} aws s3 cp \
     s3://omg-boshrelease-blobs/{} \
     s3://gds-paas-datadog-agent-boshrelease/{}
```

This PR include commits from #4, which should be merged first and this PR reviewed.
## Next steps

After this PR has been merge, we must create a binary "development release" and upload it to github as a binary release. We do it so as a temporary solution meanwhile we do not implement a process to build our own releases with a CI server. We require a binary dev release instead of build it every time because this release is also used by concourse and bosh with bosh-init.

```
bosh create release --with-tarball --name datadog-agent --version custom_007 
```

Update the PR https://github.com/alphagov/paas-cf/pull/521 once is done.

We uploaded a temporary release: https://github.com/alphagov/paas-datadog-agent-boshrelease/releases/tag/wip.122200041.1, it can be deleted later.
# What?

Datadog bundles several additional checks[1] that can run on the host from the collector. These checks usually require some configuration in the `${DD_AGENT_DIR}/conf.d/`[2].

This configuration is in form of YAML files.

Currently we generate these files in the collector ctl script from the manifest properties, but third party releases might also want to  extend datadog to monitor local services using these additional integrations.

To solve that, this commit adds logic to merge all files from jobs which follow this pattern:

```
${JOB_PATH}/config/datadog-integrations/${checkname}.yaml
```

For example:

```
/var/vcap/jobs/datadog-router/config/datadog-integrations/process.yaml
```

The script will use spruce[3] to merge all the configurations in one unique file per check, as datadog agent expects.

We also extract the logic to generate the integrations config from the manifest to a external helper file, and make it generate the files using the pattern described above.

[1] http://docs.datadoghq.com/integrations/
[2] https://github.com/DataDog/dd-agent/tree/master/conf.d
[3] https://github.com/geofffranks/spruce
# How to test this?

You can test this configuration together with the https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/1 which implements an example of this logic.

Follow the instructions in https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/1, with bosh-lite, but using a manifest like this. Change the `api_key` of datadog if you want to test if the metrics get there. The metrics will be in the form of `system.process.*`, tagged with the name of the machine.

```

---
name: learn-bosh
director_uuid: fb70f16a-4d6f-41f8-bc2e-0181a03dff18

releases:
- name: datadog-agent
  version: latest
- name: datadog-for-cloudfoundry
  version: latest
- name: routing
  version: "0.138.0"
  url: https://bosh.io/d/github.com/cloudfoundry-incubator/cf-routing-release?v=0.138.0
  sha1: 10a4bc79b8a32e4120760291975810f3855119a8
- name: nats
  version: "13"
  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=13
  sha1: bc405a67de529a9aad41ca0cf618a522d9d2b310

networks:
- name: default
  subnets:
  - range: 10.244.0.0/28
    reserved: [10.244.0.1]
    static: [10.244.0.2,10.244.0.6,10.244.0.10]
    cloud_properties:
      name: random

resource_pools:
- name: default
  stemcell:
    name: bosh-warden-boshlite-ubuntu-trusty-go_agent
    version: "3262.2"
  network: default
  cloud_properties: {}

compilation:
  workers: 2
  network: default
  cloud_properties: {}

update:
  canaries: 1
  canary_watch_time: 60000
  update_watch_time: 10000-300000
  max_in_flight: 2

jobs:
- name: nats
  templates:
  - name: nats
    release: nats
  instances: 1
  resource_pool: default
  networks:
  - name: default
    static_ips:
    - 10.244.0.6

- name: app
  templates:
  - name: datadog-agent
    release: datadog-agent
  - name: datadog-router
    release: datadog-for-cloudfoundry
  - name: gorouter
    release: routing


  instances: 1
  resource_pool: default
  networks:
  - name: default
    static_ips:
    - 10.244.0.2
properties:
  api_key: ....
  hostname: hehe
  tags:
    env: bosh-lite
  router:
    enable_ssl: false
    requested_route_registration_interval_in_seconds:
    ssl_skip_validation:
    status:
      port:
      user: router_user
      password: password
    secure_cookies:
    route_services_secret:
    route_services_secret_decrypt_only:
    route_services_timeout:
    logrotate:
    extra_headers_to_log:
    debug_address:
    enable_routing_api:
    drain_wait: 15
  nats:
    port: 4222
    machines:
    - 10.244.0.6
    debug: false
    trace: false
    monitor_port: 0
    prof_port: 0
    user: nats_user
    password: aaa
  uaa:
    clients:
      gorouter:
        secret: 1234
    ssl:
      port: 123

```
## Who?

Anyone but @richardc or @keymon 
