### PR TITLE
Fix hostname logic

### DIFF
--- a/jobs/datadog-agent/templates/config/datadog.conf.erb
+++ b/jobs/datadog-agent/templates/config/datadog.conf.erb
@@ -23,7 +23,7 @@ api_key: <%= p('api_key') %>
 # Force the hostname to whatever you want.
 <%
 hostname = nil
-if_p('use_bosh_hostname') do |h|
+if p('use_bosh_hostname')
     hostname = "#{spec.name || 'unknown'}.#{spec.index || '0'}"
 end
 if_p('hostname') do |h|


### PR DESCRIPTION
## What
Fix template logic for setting custom hostnames:

if_p only checks if property exists (is set). Which is always true for
use_bosh_hostname as we give it default of false in the spec.

This means that template would _always_ render as if use_bosh_hostname was
true, regardless of actual value. Change it to real `if` to fix logic. We
don't need to test if the property is set at all, because we give it default
value.

## Testing
Deploy. Note that bosh hostname (e.g. router.0) is used for `hostname` value when you set `use_bosh_hostname` to true and not used otherwise.

## Who
not @mtekel