### PR TITLE
[#148059799] Fix the directory permissions

### DIFF
--- a/jobs/datadog-agent/templates/helpers/ctl_setup.sh
+++ b/jobs/datadog-agent/templates/helpers/ctl_setup.sh
@@ -61,7 +61,6 @@ for dir in $RUN_DIR $LOG_DIR $TMP_DIR $STORE_DIR
 do
   mkdir -p ${dir}
   chown vcap:vcap ${dir}
-  chmod 775 ${dir}
 done
 export TMPDIR=$TMP_DIR
 


### PR DESCRIPTION
## What

The current chmod on these folders is `775`. This causes `logrotate` to
throw an error and prevent the files inside to be rotated to save some
space.

The folder should be set to `755` which is the default chmod upon
creation. We're removing the line that causes us problems.

## How to review

- Sanity check
- May want to run the pipeline pointing to this release and see it succeed - I haven't done that.