### PR TITLE
[#155398419] Chown config files to vcap:vcap and upgrade from upstream

### DIFF
--- a/.final_builds/jobs/datadog-agent/index.yml
+++ b/.final_builds/jobs/datadog-agent/index.yml
@@ -16,4 +16,8 @@ builds:
     version: fbe3b5842af0bf6ed3251564e5767efc54141946
     sha1: fac2a769eff312e4cc4b3a56e973a738019f3821
     blobstore_id: 774fee7c-08cf-4455-bb11-0f6d0985784e
+  ba41def58adb613754bf516fbb131deaa31ff8da:
+    version: ba41def58adb613754bf516fbb131deaa31ff8da
+    sha1: 71c4ef7b0da30e7964be346b783e238285b1816d
+    blobstore_id: 50773bdf-8bf1-4b83-82ad-765c9d759cdd
 format-version: '2'

--- a/README.md
+++ b/README.md
@@ -103,13 +103,13 @@ The script will use [spruce](https://github.com/geofffranks/spruce) to merge all
 
 #### Using custom checks from 3rd party releases
 
-This release has built-in logic that collects custom datadog checks from 3rd party releases and copies them to `checks.d` directory of the datadog agent. Configuration for these custom checks is transferred/merged using logic described above in [Configuring integrations from 3rd party releases]. The custom checks are collected from this path in the releases:
+This release has built-in logic that collects custom datadog checks from 3rd party releases and copies them to `checks.d` directory of the datadog agent. Configuration for these custom checks is transferred/merged using logic described above in [Configuring integrations from 3rd party releases](#configuring-integrations-from-3rd-party-releases). The custom checks are collected from this path in the releases:
 
-  ${JOB_PATH}/config/datadog-integrations/${checkname}.py
+    ${JOB_PATH}/config/datadog-integrations/${checkname}.py
 
 E.g.
 
-  /var/vcap/jobs/datadog-bbs/config/datadog-integrations/bbs_check.py
+    /var/vcap/jobs/datadog-bbs/config/datadog-integrations/bbs_check.py
 
 If there happen to be two custom checks with the same name, script will abort startup, causing BOSH to fail deploying this job. This is because checks are written in python and are not easily mergable like yaml files. Overwritting checks is not desired, nor is silent failure.
 

--- a/jobs/datadog-agent/templates/bin/collector_ctl
+++ b/jobs/datadog-agent/templates/bin/collector_ctl
@@ -16,6 +16,8 @@ case $1 in
     pid_guard $PIDFILE $JOB_NAME
 
     cp $JOB_DIR/config/datadog.conf "$AGENT_DIR/"
+    chown vcap:vcap "$AGENT_DIR/datadog.conf"
+
     bash $JOB_DIR/helpers/generate_integrations_conf.sh
     bash $JOB_DIR/helpers/merge_integrations_conf.sh
     bash $JOB_DIR/helpers/collect_custom_checks.sh

--- a/jobs/datadog-agent/templates/bin/dogstatsd_ctl
+++ b/jobs/datadog-agent/templates/bin/dogstatsd_ctl
@@ -9,6 +9,14 @@ export PORT=${PORT:-5000}
 export LANG=en_US.UTF-8
 PIDFILE=$RUN_DIR/dogstatsd.pid
 
+ensure_log_file_owned_by_vcap() {
+  # Make sure the dogstatsd.log file exists otherwise it will be created
+  # with owner root:root when dogstatsd.py is started the first time.
+  # The output redirection is not affected by chpst.
+  [ -e "$LOG_DIR/dogstatsd.log" ] || touch "$LOG_DIR/dogstatsd.log"
+  chown vcap:vcap "$LOG_DIR/dogstatsd.log"
+}
+
 case $1 in
 
   start)
@@ -19,6 +27,8 @@ case $1 in
 
     cp $JOB_DIR/config/datadog.conf "$AGENT_DIR/"
     chown vcap:vcap "$AGENT_DIR/datadog.conf"
+
+    ensure_log_file_owned_by_vcap
 
     exec chpst -u vcap:vcap \
       python "$AGENT_DIR/dogstatsd.py" --use-local-forwarder \

--- a/jobs/datadog-agent/templates/bin/dogstatsd_ctl
+++ b/jobs/datadog-agent/templates/bin/dogstatsd_ctl
@@ -18,6 +18,7 @@ case $1 in
     echo $$ > $PIDFILE
 
     cp $JOB_DIR/config/datadog.conf "$AGENT_DIR/"
+    chown vcap:vcap "$AGENT_DIR/datadog.conf"
 
     exec chpst -u vcap:vcap \
       python "$AGENT_DIR/dogstatsd.py" --use-local-forwarder \

--- a/jobs/datadog-agent/templates/bin/forwarder_ctl
+++ b/jobs/datadog-agent/templates/bin/forwarder_ctl
@@ -11,10 +11,11 @@ export LANG=en_US.UTF-8
 PIDFILE=$RUN_DIR/forwarder.pid
 
 ensure_log_file_owned_by_vcap() {
-  if [ -e "$LOG_DIR/forwarder.log" ]
-  then
-    chown vcap:vcap "$LOG_DIR/forwarder.log"
-  fi
+  # Make sure the forwarder.log file exists otherwise it will be created
+  # with owner root:root when ddagent.py is started the first time.
+  # The output redirection is not affected by chpst.
+  [ -e "$LOG_DIR/forwarder.log" ] || touch "$LOG_DIR/forwarder.log"
+  chown vcap:vcap "$LOG_DIR/forwarder.log"
 }
 
 case $1 in

--- a/jobs/datadog-agent/templates/bin/forwarder_ctl
+++ b/jobs/datadog-agent/templates/bin/forwarder_ctl
@@ -3,6 +3,7 @@
 set -e # exit immediately if a simple command exits with a non-zero status
 
 # Setup env vars and folders for the webapp_ctl script
+# shellcheck source=/dev/null
 source /var/vcap/jobs/datadog-agent/helpers/ctl_setup.sh 'datadog-agent'
 
 export PORT=${PORT:-5000}
@@ -19,23 +20,23 @@ ensure_log_file_owned_by_vcap() {
 case $1 in
 
   start)
-    pid_guard $PIDFILE $JOB_NAME
+    pid_guard "$PIDFILE" "$JOB_NAME"
 
     # store pid in $PIDFILE
-    echo $$ > $PIDFILE
+    echo $$ > "$PIDFILE"
 
-    cp $JOB_DIR/config/datadog.conf "$AGENT_DIR/"
+    cp "$JOB_DIR/config/datadog.conf" "$AGENT_DIR/"
 
     ensure_log_file_owned_by_vcap
 
     exec chpst -u vcap:vcap \
       python "$AGENT_DIR/ddagent.py" --use_simple_http_client=1 \
-      >>$LOG_DIR/forwarder.log 2>&1
+      >>"$LOG_DIR/forwarder.log" 2>&1
 
     ;;
 
   stop)
-    kill_and_wait $PIDFILE
+    kill_and_wait "$PIDFILE"
 
     ;;
   *)

--- a/jobs/datadog-agent/templates/bin/forwarder_ctl
+++ b/jobs/datadog-agent/templates/bin/forwarder_ctl
@@ -26,6 +26,7 @@ case $1 in
     echo $$ > "$PIDFILE"
 
     cp "$JOB_DIR/config/datadog.conf" "$AGENT_DIR/"
+    chown vcap:vcap "$AGENT_DIR/datadog.conf"
 
     ensure_log_file_owned_by_vcap
 

--- a/jobs/datadog-agent/templates/bin/forwarder_ctl
+++ b/jobs/datadog-agent/templates/bin/forwarder_ctl
@@ -9,6 +9,13 @@ export PORT=${PORT:-5000}
 export LANG=en_US.UTF-8
 PIDFILE=$RUN_DIR/forwarder.pid
 
+ensure_log_file_owned_by_vcap() {
+  if [ -e "$LOG_DIR/forwarder.log" ]
+  then
+    chown vcap:vcap "$LOG_DIR/forwarder.log"
+  fi
+}
+
 case $1 in
 
   start)
@@ -18,6 +25,8 @@ case $1 in
     echo $$ > $PIDFILE
 
     cp $JOB_DIR/config/datadog.conf "$AGENT_DIR/"
+
+    ensure_log_file_owned_by_vcap
 
     exec chpst -u vcap:vcap \
       python "$AGENT_DIR/ddagent.py" --use_simple_http_client=1 \

--- a/jobs/datadog-agent/templates/config/datadog.conf.erb
+++ b/jobs/datadog-agent/templates/config/datadog.conf.erb
@@ -27,7 +27,7 @@ if p('use_bosh_hostname')
   hostname = "#{[spec.deployment, spec.name, spec.index].join('.')}"
 end
 if_p('hostname') do |h|
-    hostname = h
+  hostname = h
 end
 
 if hostname && !hostname.empty?

--- a/jobs/datadog-agent/templates/config/datadog.conf.erb
+++ b/jobs/datadog-agent/templates/config/datadog.conf.erb
@@ -24,13 +24,13 @@ api_key: <%= p('api_key') %>
 <%
 hostname = nil
 if p('use_bosh_hostname')
-    hostname = "#{spec.name || 'unknown'}.#{spec.index || '0'}"
+  hostname = "#{[spec.deployment, spec.name, spec.index].join('.')}"
 end
 if_p('hostname') do |h|
     hostname = h
 end
 
-if hostname
+if hostname && !hostname.empty?
 %>
 hostname: <%= hostname %>
 <% end %>

--- a/releases/datadog-agent/datadog-agent-5.8.5.5.yml
+++ b/releases/datadog-agent/datadog-agent-5.8.5.5.yml
@@ -1,0 +1,31 @@
+---
+packages:
+- name: datadog-agent
+  version: f466dd5ff097ebf5ca729e3a8e1a79e5abad989b
+  fingerprint: f466dd5ff097ebf5ca729e3a8e1a79e5abad989b
+  sha1: '068a9f520ddad12c34eae4963be0c0fa9f6c8092'
+  dependencies:
+  - python-dev
+- name: python-dev
+  version: e3b2dd781300c56102aa046428069c2648ddd4a5
+  fingerprint: e3b2dd781300c56102aa046428069c2648ddd4a5
+  sha1: 190536c377c3bbd0a0e44e1b58857d7542a6c58e
+  dependencies: []
+- name: spruce
+  version: 6b63abd6e8a015478e5b8fb329741659caeda994
+  fingerprint: 6b63abd6e8a015478e5b8fb329741659caeda994
+  sha1: bebb2b2b550074bef60b7a4e9cbd61c32c17ad90
+  dependencies: []
+jobs:
+- name: datadog-agent
+  version: ba41def58adb613754bf516fbb131deaa31ff8da
+  fingerprint: ba41def58adb613754bf516fbb131deaa31ff8da
+  sha1: 71c4ef7b0da30e7964be346b783e238285b1816d
+license:
+  version: 94ec8797c1898217dbe180bb79797f5650233335
+  fingerprint: 94ec8797c1898217dbe180bb79797f5650233335
+  sha1: fd89eb46cac1d9ed12ef859e7be2c9de11b0f6c2
+commit_hash: 2d379840
+uncommitted_changes: true
+name: datadog-agent
+version: 5.8.5.5

--- a/releases/datadog-agent/index.yml
+++ b/releases/datadog-agent/index.yml
@@ -10,4 +10,6 @@ builds:
     version: 5.8.5.3
   ef5ecab2-ef6a-4e5d-9dba-fbdf7e8e262f:
     version: 5.8.5.4
+  '09a48fc0-64cd-4a8c-bec0-017fd90a59a7':
+    version: 5.8.5.5
 format-version: '2'


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/155398419

## What

❗️ This PR was previously open wrongly against the master branch: https://github.com/alphagov/paas-datadog-agent-boshrelease/pull/12. Master has been reset to upstream.

Chown config and log files to vcap:vcap

Starting from 3541.2 the permissions in /var/vcap/* are hardened. (They also changed the default umask to 0700 in 3541.2 [1] but it was reverted to in 3541.4 [2])

The stemcell change means files owned by root are not readable anymore by processes running by the vcap user.

We'll chown the config directory and fix the ownership when the datadog.conf file is copied to its final place.

We also have to explicitly create some log files and chown them as processes are running with chpst but the output redirection is not affected by that.

Also I pulled the latest changes from upstream. The changes seem to be low risk (note: use_bosh_hostname is not used by us, so the hostname change won't affect us)

Note: I also fixed the permissions for dogstatsd.log but we don't use the process which writes to it.

[1] https://github.com/cloudfoundry/bosh-linux-stemcell-builder/releases/tag/stable-3541.2
[2] https://github.com/cloudfoundry/bosh-linux-stemcell-builder/releases/tag/stable-3541.4

## How to review

Code review.

To test it follow the instructions from:
 * https://github.com/alphagov/paas-cf/pull/1256
 * https://github.com/alphagov/paas-bootstrap/pull/144

If the PR is merged we also need to open an upstream PR for https://github.com/onemedical/datadog-agent-boshrelease

## Who can review it

Not me.